### PR TITLE
Fixed few issue during testing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,8 +18,6 @@ module.exports = async ({username, tenant, apikey}) => {
 	}
 
 	const weclapp = {
-		user: null,
-
 		/**
 		 * Makes a request to the weclapp rest-api
 		 * @param endpoint Endpoint
@@ -52,11 +50,8 @@ module.exports = async ({username, tenant, apikey}) => {
 		}
 	}
 
-	// Check credentials
-	return weclapp.fetch('user/currentUser').then(user => {
-
 		// Resolve endpoints
-		const endpoints = './src/endpoints'
+		const endpoints = __dirname+'/endpoints'
 		const modules = fs.readdirSync(path.resolve(endpoints))
 			.map(v => require(path.resolve(endpoints, v)))
 			.reduce((pv, cv) => ({...pv, ...cv}), {})
@@ -67,9 +62,7 @@ module.exports = async ({username, tenant, apikey}) => {
 		}
 
 		return {
-			user: user && user.result,
 			...weclapp,
 			...modules
 		}
-	})
 }

--- a/src/endpoints/ticket.js
+++ b/src/endpoints/ticket.js
@@ -1,0 +1,65 @@
+const {buildUrl} = require('../utils')
+
+module.exports = {
+
+	/**
+	 * @param page
+	 * @param pageSize
+	 * @param sort
+	 * @returns {Promise<*|Promise<*>|Promise|Promise<Response>|never>}
+	 */
+	async getTickets(fetch, {page, pageSize, sort}) {
+		return fetch(buildUrl('ticket', {page, pageSize, sort}))
+	},
+
+	/**
+	 * @param body
+	 * @returns {Promise<*|Promise<*>|Promise|Promise<Response>|never>}
+	 */
+	async createTicket(fetch, body) {
+		return fetch('ticket', {method: 'POST', body})
+	},
+
+	/**
+	 * @returns {Promise<*|Promise<*>|Promise|Promise<Response>|never>}
+	 */
+	async getTicketCount(fetch) {
+		return fetch('ticket/count')
+	},
+
+	/**
+	 * @param id
+	 * @returns {Promise<*|Promise<*>|Promise|Promise<Response>|never>}
+	 */
+	async getTicketById(fetch, id) {
+		return fetch(buildUrl(`ticket/id/${id}`, {id}))
+	},
+
+	/**
+	 * @param id
+	 * @param body
+	 * @returns {Promise<*|Promise<*>|Promise|Promise<Response>|never>}
+	 */
+	async updateTicketForId(fetch, id, body) {
+		return fetch(buildUrl(`ticket/id/${id}`, {id}), {method: 'PUT', body})
+	},
+
+	/**
+	 * @param id
+	 * @param scaleWidth
+	 * @param scaleHeight
+	 * @returns {Promise<*|Promise<*>|Promise|Promise<Response>|never>}
+	 */
+	async getTicketExtraInfoForAppById(fetch, {id}) {
+		return fetch(buildUrl(`ticket/id/${id}/extraInfoForApp`, {id}))
+	},
+
+	/**
+	 * @param id
+	 * @param body
+	 * @returns {Promise<*|Promise<*>|Promise|Promise<Response>|never>}
+	 */
+	async createTicketExtraInfoForAppForId(fetch, id, body) {
+		return fetch(buildUrl(`ticket/id/${id}/extraInfoForApp`, {id}), {method: 'POST', body})
+	}
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,6 @@
+const { URLSearchParams } = require('url');
+global.URLSearchParams = URLSearchParams
+
 module.exports = {
 
 	/**


### PR DESCRIPTION
fixed  Below Issue
1.  As discussed we don't need to call `user/currentuser` before making any call as authentication is already included with endpoint itself (using basic auth). @Simonwep seems you forgot to delete 😄 
2.  added `const endpoints = __dirname+'/endpoints'` 
     `./endpoints` was not resolving correct path in my window machine. please cross check in your 
     environment before merging. 
3.  added `URLSearchParams` as global because only `10+` node version has [built-in availability](https://stackoverflow.com/questions/47266550/how-to-use-global-urlsearchparams-in-node/48762804#48762804). we should consider `8+` module support as discuss earlier.